### PR TITLE
Add docs, license, a few other things to make this work as its own repo

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,1 @@
+* FundingCircle/architecture

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020, Funding Circle
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
 # DaD
 
-DaD is our homegrown *Docs as Data* tool.
+DaD is a [Docs as Data][docs-as-data] toolkit — a [CLI][cli] tool *and* a [Clojure][clojure]
+library.
 
-Right now it’s focused on building/rendering textual documents/pages from data+templates.
+Right now it’s focused on:
+
+* Authoring and maintaining a database that is reified as a set of [YAML][yaml] files
+* Rendering textual documents/pages from that database and a set of [templates][templates]
+
+
+## Status
+
+This tool is in a very early stage of development, and is probably not suitable for anyone but its
+developers to use.
+
+**If** you’re familiar with Clojure, [Markdown][markdown], **and** templating systems such as
+[Django][django], [Jinja][jinja], or [Liquid][liquid], **and** you’re comfortable reading the
+source code thoroughly before usage, **and** you’re comfortable running the tool from a Clojure
+[REPL][repl] — then it *might* not be a terrible idea for you to try using this tool.
+
+
+## Documentation
+
+* [Contributing][contributing]
+
+
+[cli]: https://en.wikipedia.org/wiki/Command-line_interface
+[clojure]: https://clojure.org/
+[contributing]: doc/contributing.md
+[django]: https://www.djangoproject.com/
+[docs-as-data]: doc/docs-as-data.md
+[jinja]: https://jinja.palletsprojects.com/en/2.11.x/
+[liquid]: https://shopify.github.io/liquid/
+[markdown]: https://en.wikipedia.org/wiki/Markdown
+[repl]: https://en.wikipedia.org/wiki/REPL
+[templates]: doc/templates.md
+[yaml]: https://yaml.org/

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,0 +1,73 @@
+# Contributing to DaD
+
+Contributions — including any and all feedback — are welcome and greatly appreciated!
+
+
+## Feedback
+
+Any and all feedback — questions, suggestions, bug reports, experience reports, etc — is welcome.
+Please [create an issue][new-issue] and one of the maintainers will get back to you.
+
+[new-issue]: https://github.com/FundingCircle/dad/issues/new
+
+
+## Code and Documentation
+
+If you wish to contribute code and/or documentation changes (which would be fantastic) you must:
+
+* Read and agree to the _Developer Certificate of Origin_ below
+* Include this statement in each commit message:
+
+  ```text
+  This change is authored by and contributed to the project “DaD” by
+  Random J Developer <random@developer.example.org> who hereby certifies
+  each statement included in the project’s Developer Certificate of
+  Origin located at https://git.io/Jf4Qx
+  ```
+
+  using your real name and email address.
+
+### Developer Certificate of Origin
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright © 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right
+    to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate open source license and I have
+    the right under that license to submit that work with modifications, whether
+    created in whole or in part by me, under the same open source license
+    (unless I am permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other person who
+    certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public and
+    that a record of the contribution (including all personal information I
+    submit with it, including my sign-off) is maintained indefinitely and may be
+    redistributed consistent with this project or the open source license(s)
+    involved.
+```
+
+### License
+
+All contributions to this project are licensed under [the project’s license][license].
+
+
+[license]: https://github.com/FundingCircle/dad/blob/master/LICENSE

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,0 +1,46 @@
+# Developing and Testing DaD
+
+Coming soon.
+
+<!-- COMING SOON
+
+This project uses [Kaocha][kaocha] as its test runner.
+
+Each subdirectory under [`test`][test-dir] is a test suite, e.g. `examples`, `integration`,
+`property`, etc.
+
+
+## Running the tests
+
+### From a shell
+
+```shell
+# Run all suites
+bin/kaocha
+
+# Run a single suite
+bin/kaocha integration
+```
+
+### From a REPL
+
+```clojure
+(use 'kaocha.repl)
+
+; Run all suites
+(run-all)
+
+; Run a single suite
+(run :unit)
+
+; Run a single namespace
+(run 'dad.db-test)
+
+; Run a single test var
+(run 'dad.db-test/test-add-meta)
+```
+
+
+[kaocha]: https://github.com/lambdaisland/kaocha
+[test-dir]: ../test/
+-->

--- a/doc/docs-as-data.md
+++ b/doc/docs-as-data.md
@@ -1,0 +1,15 @@
+# Docs as Data
+
+I’m terribly sorry, but I have not yet had a chance to articulate what this *is* exactly, not
+really, not quite yet. You see, I’ve been applying the [Docs as **Code**][dac] philosophy within
+[Funding Circle][funding-circle] for a few years, to great effect. But I found that for my
+particular efforts, *Docs as Code* didn’t go quite far enough. I realized (slowly) that my efforts
+would be best served by reifying the content of my documentation, and my team’s documentation, as
+*data*. It took me some time and some exploration to start to figure out what that might mean, and
+I’ve made some progress — but not *quite* enough to actually explain what this is. Yet.
+
+Soon!
+
+
+[dac]: https://www.writethedocs.org/guide/docs-as-code/
+[funding-circle]: https://github.com/FundingCircle/

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -1,0 +1,7 @@
+# Document Templates
+
+DaD uses [Selmer][selmer] as its templating system — that, plus [a set of custom filters][filters].
+
+
+[filters]: https://github.com/FundingCircle/dad/blob/master/src/dad/rendering/filters.clj
+[selmer]: https://github.com/yogthos/Selmer

--- a/src/dad/rendering.clj
+++ b/src/dad/rendering.clj
@@ -1,85 +1,10 @@
 (ns dad.rendering
   (:require [clojure.java.io :refer [file]]
-            [clojure.string :as str :refer [lower-case]]
+            [clojure.string :as str]
             [dad.files :as files :refer [relative-path]]
             [dad.yaml :as yaml]
-            [medley.core :as mc]
-            [selmer.filters :as filters]
-            [selmer.parser :as parser :refer [render]])
-  (:import [java.time LocalDate ZonedDateTime]))
-
-(defn- flexi-get
-  ([coll k]
-   (flexi-get coll k nil))
-  ([coll k d]
-   (or (get coll k)
-       (get coll (name k))
-       (get coll (lower-case (name k)))
-       (get coll (keyword (lower-case (name k))))
-       d)))
-
-(defn- flex=
-  [& vs]
-  (apply = (map (comp lower-case name) vs)))
-
-(def to-pattern (memoize re-pattern))
-
-(def filters
-  ;; TODO: some of these names are iffy. Rethink!
-  {:filter-by (fn [m k v]
-                (->> m
-                     (mc/filter-vals (fn [im] (flex= (flexi-get im k) v)))
-                     (into (empty m))))
-   :get flexi-get
-
-   :includes? str/includes?
-
-   :join (fn [coll separator] (str/join separator coll))
-
-   ; Given a sequence of maps, sort them by the specified date/time property, then return the map
-   ; with the most recent date value in that property. The values must be either ISO-8601 dates
-   ; (2020-04-20) or (COMING SOON) ISO-8601 date-times (2020-04-20T16:20:00-04:00).
-   ; TODO: what should this do if the value isn’t a sequence of maps? Or if one or more of the maps
-   ;       don’t have the specified property (key)?
-   :latest-by (fn [maps k]
-                (last (sort-by (fn [m] (LocalDate/parse (get m k))) maps)))
-
-   ;; This needs to produce the same slugs that GitHub generates when rendering Markdown into HTML.
-   ;; (GH generates “permalinks” for every Markdown header; the anchor is a slugified version of
-   ;; the header text.)
-   ;; We should probably replace this sketchy impl with one from a third-party library.
-   :slugify #(some-> %
-                     (name)
-                     (lower-case)
-                     (str/replace #"\s" "-")
-                     (str/replace #"[^-_A-Za-z0-9]" ""))
-
-   :parse-date-time #(try (when-not (str/blank? %) (ZonedDateTime/parse %))
-                          (catch Exception _e nil))
-
-   ; This name isn’t clear. It’s really sort-by-nested-key as it assumes that the input is a coll
-   ; of maps. Gotta figure this out.
-   :sort-by-key (fn [coll k]
-                  (into (empty coll)
-                        (sort-by (fn [[_k v]] (lower-case (flexi-get v k)))
-                                 coll)))
-   :sort-by-keys #(into (empty %)
-                        (sort-by (fn [[k _v]] (lower-case (name k))) %))
-   :sort-by-names (fn [coll]
-                    (sort-by (fn [[k v]]
-                               (lower-case (flexi-get v "full-name" (name k))))
-                             coll))
-   :split (fn [s regex] (str/split s (to-pattern regex)))
-   :without (fn [coll k]
-              (remove (fn [[_name props]]
-                        (or (contains? props k)
-                            (contains? props (keyword k))))
-                      coll))})
-
-(defn- register-filters!
-  []
-  (doseq [[n f] filters]
-    (filters/add-filter! n f)))
+            [dad.rendering.filters :as filters]
+            [selmer.parser :as parser :refer [render]]))
 
 (defn- reduce-whitespace
   "Selmer doesn’t have any whitespace control features, so we use this function in post-processing
@@ -159,7 +84,7 @@
   NB: the values of :dad/template-path are relative to templates-path. In other words, they don’t
   contain templates-path."
   [db templates-dir repo-root-dir]
-  (register-filters!)
+  (filters/register!)
   (->> (file-seq (file templates-dir))
        (filter (memfn isFile)) ;; TODO: this breaks if there’s a binary file, e.g. .DS_Store
 

--- a/src/dad/rendering/filters.clj
+++ b/src/dad/rendering/filters.clj
@@ -1,0 +1,83 @@
+(ns dad.rendering.filters
+  "These filters were part of this codebase when it was just a subtree in a larger private internal
+  repo within Funding Circle; they’re included here for now because for now we don’t have a better
+  place to keep them. We should probably remove them from this project soon, because they’re highly
+  specific to the needs of the Architecture team at Funding Circle, and this project is now intended
+  to be useable/useful for people in other contexts outside of Funding Circle."
+  (:require [clojure.string :as str :refer [lower-case]]
+            [medley.core :as mc]
+            [selmer.filters :as filters])
+  (:import [java.time LocalDate ZonedDateTime]))
+
+(defn- flexi-get
+  ([coll k]
+   (flexi-get coll k nil))
+  ([coll k d]
+   (or (get coll k)
+       (get coll (name k))
+       (get coll (lower-case (name k)))
+       (get coll (keyword (lower-case (name k))))
+       d)))
+
+(defn- flex=
+  [& vs]
+  (apply = (map (comp lower-case name) vs)))
+
+(def ^:private to-pattern (memoize re-pattern))
+
+(def filters
+  ;; TODO: some of these names are iffy. Rethink!
+  {:filter-by (fn [m k v]
+                (->> m
+                     (mc/filter-vals (fn [im] (flex= (flexi-get im k) v)))
+                     (into (empty m))))
+   :get flexi-get
+
+   :includes? str/includes?
+
+   :join (fn [coll separator] (str/join separator coll))
+
+   ; Given a sequence of maps, sort them by the specified date/time property, then return the map
+   ; with the most recent date value in that property. The values must be either ISO-8601 dates
+   ; (2020-04-20) or (COMING SOON) ISO-8601 date-times (2020-04-20T16:20:00-04:00).
+   ; TODO: what should this do if the value isn’t a sequence of maps? Or if one or more of the maps
+   ;       don’t have the specified property (key)?
+   :latest-by (fn [maps k]
+                (last (sort-by (fn [m] (LocalDate/parse (get m k))) maps)))
+
+   ;; This needs to produce the same slugs that GitHub generates when rendering Markdown into HTML.
+   ;; (GH generates “permalinks” for every Markdown header; the anchor is a slugified version of
+   ;; the header text.)
+   ;; We should probably replace this sketchy impl with one from a third-party library.
+   :slugify #(some-> %
+                     (name)
+                     (lower-case)
+                     (str/replace #"\s" "-")
+                     (str/replace #"[^-_A-Za-z0-9]" ""))
+
+   :parse-date-time #(try (when-not (str/blank? %) (ZonedDateTime/parse %))
+                          (catch Exception _e nil))
+
+   ; This name isn’t clear. It’s really sort-by-nested-key as it assumes that the input is a coll
+   ; of maps. Gotta figure this out.
+   :sort-by-key (fn [coll k]
+                  (into (empty coll)
+                        (sort-by (fn [[_k v]] (lower-case (flexi-get v k)))
+                                 coll)))
+   :sort-by-keys #(into (empty %)
+                        (sort-by (fn [[k _v]] (lower-case (name k))) %))
+   :sort-by-names (fn [coll]
+                    (sort-by (fn [[k v]]
+                               (lower-case (flexi-get v "full-name" (name k))))
+                             coll))
+   :split (fn [s regex] (str/split s (to-pattern regex)))
+   :without (fn [coll k]
+              (remove (fn [[_name props]]
+                        (or (contains? props k)
+                            (contains? props (keyword k))))
+                      coll))})
+
+(defn register!
+  []
+  (doseq [[n f] filters]
+    (filters/add-filter! n f)))

--- a/test/.gitkeep
+++ b/test/.gitkeep
@@ -1,0 +1,6 @@
+Dear Git,
+
+Please don’t delete this directory. I have big plans for it. Thank you!
+
+Sincerely,
+Avi


### PR DESCRIPTION
And a few other odds and ends that should help the project function as
a standalone repo, such as .github/codeowners.

Much of this wasn’t necessary until now, now that this project has been
extracted into its own repo.

I also split the custom filters out into their own Clojure namespace, so
that I could link to them clearly and easily from the docs.