### PR TITLE
Add new CLI command to rebuild the DB

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,8 @@
 {:deps
- {clj-commons/clj-yaml  {:mvn/version "0.7.0"}
+ {cli-matic             {:git/url "https://github.com/l3nz/cli-matic"
+                         :sha "2640ad5b6dcc2ae0638f79d0edb9f007351487b0"
+                         :tag "v0.3.11"}
+  clj-commons/clj-yaml  {:mvn/version "0.7.0"}
   medley                {:git/url "https://github.com/weavejester/medley"
                          :sha "6c79c4cce52b276daa3c2b6eaea78f96904bca56"
                          :tag "1.3.0"}
@@ -10,6 +13,6 @@
                           "--illegal-access=deny"
                           "-Dclojure.server.repl={:port,0,:accept,clojure.core.server/repl}"]}
 
-  :run        {:jvm-opts ["-Dapple.awt.UIElement=true" "-Djava.awt.headless=true"]}
-
-  :build-docs {:main-opts ["-m" "dad.cli"]}}}
+  :main        {:main-opts ["-m" "dad.cli"]}
+                :jvm-opts ["-Dapple.awt.UIElement=true"
+                           "-Djava.awt.headless=true"]}}

--- a/src/dad/cli.clj
+++ b/src/dad/cli.clj
@@ -1,17 +1,53 @@
 (ns dad.cli
-  (:require [clojure.string :as str]
+  (:require [cli-matic.core :refer [run-cmd]]
+            [clojure.java.io :refer [file]]
             [dad.db :as db]
             [dad.io :as io]
             [dad.rendering :as r]))
 
+(defn- exists?!
+  [[opt-name s]]
+  (let [f (file s)]
+    (when-not (.isDirectory f)
+      (throw (RuntimeException. (format "The path supplied for %s, %s, must be a directory!"
+                                        opt-name
+                                        s))))))
+
+(defn- build
+  [{:keys [db templates project-root out] :as opts}]
+  (run! exists?! (select-keys opts [:db :templates :project-root :out]))
+  (-> (db/read db)
+      (r/build-docs templates project-root)
+      (io/write-docs! out templates project-root)))
+
+(def config
+  ;; The spec for this is here: https://github.com/l3nz/cli-matic/blob/master/README.md
+  ;; :default :present means required ¯\_(ツ)_/¯
+  {:app         {:command     "dad"
+                 :description "Toolkit for “Docs as Data”"
+                 :version     "TBD"}
+   :commands    [{:command     "build"
+                  :description (str "Generates document files as per the document templates and the"
+                                    " data in the database.")
+                  :opts        [{:option  "db"
+                                 :as      "The path to the database directory"
+                                 :type    :string
+                                 :default :present}
+                                {:option  "templates"
+                                 :as      "The path to the templates directory"
+                                 :type    :string
+                                 :default :present}
+                                {:option  "project-root"
+                                 :as      "The path to directory that is the root of the project"
+                                 :type    :string
+                                 :default :present}
+                                {:option  "out"
+                                 :as      (str "The path to directory to which the generated"
+                                               " documents should be written")
+                                 :type    :string
+                                 :default :present}]
+                   :runs build}]})
+
 (defn -main
-  [& [data-dir templates-dir out-dir repo-root-dir :as _args]]
-  ;; TODO: this is primitive; switch to clojure.tools.cli
-  (when (some str/blank? [data-dir templates-dir out-dir])
-    (println (str "ERROR one or more required arguments are missing or blank.\n"
-                  "USAGE: <program> DATA-PATH TEMPLATES-PATH OUT-PATH"))
-    (System/exit 1))
-  ; (println "args:" args) ; TODO: add a debug flag
-  (-> (db/read data-dir)
-      (r/build-docs templates-dir repo-root-dir)
-      (io/write-docs! out-dir templates-dir repo-root-dir)))
+  [& args]
+  (run-cmd args config))


### PR DESCRIPTION
Which necessitated adding a command for rendering documents, which until now was the only feature accessible to users at the command-line.

I recommend reviewing each commit individually.