### PR TITLE
Add new custom tag `removeblanklines`

### DIFF
--- a/src/dad/rendering/tags.clj
+++ b/src/dad/rendering/tags.clj
@@ -9,10 +9,25 @@
   are preserved as scalar values. But for some reason it includes those double-quotes as part of the
   values. We don’t want them, so this removes them."
   [s]
-  (if (and (str/starts-with? s "\"")
+  (if (and (string? s)
+           (str/starts-with? s "\"")
            (str/ends-with? s "\""))
     (subs s 1 (dec (count s)))
     s))
+
+(def ^:private remove-blank-lines
+  "A full custom tag “spec” as required by selmer.parser/add-tag! — a sequence of either
+  2 or 3 values; in this case, 3 values: the opening tag, the fn, and the closing tag. This is all
+  packaged together because the function needs to “know” the tag name that’s used for it, so that
+  it can retrieve the content it needs. (This is how Selmer works; I don’t know why). I wanted to
+  keep that all “local” so it wouldn’t be spread around in a few places. This way, if we change the
+  name of the tag, all the changes will be localized in this one place."
+  (let [opening-tag :removeblanklines
+        closing-tag :endremoveblanklines]
+    (vector opening-tag
+            (fn removeblanklines [_args _context content]
+              (str/replace (get-in content [opening-tag :content]) #"\n{2,}" "\n"))
+            closing-tag)))
 
 (defn- exec
   [args _context]
@@ -25,9 +40,12 @@
          (format "Command » %s « failed: %s" (str/join " " args) e))))
 
 (def tags
-  {:exec exec})
+  [remove-blank-lines
+   [:exec exec]])
 
 (defn register!
   []
-  (doseq [[name f] tags]
-    (sp/add-tag! name f)))
+  (doseq [[opening f closing] tags]
+    (if closing ; we can’t use apply because add-tag! is a macro
+      (sp/add-tag! opening f closing)
+      (sp/add-tag! opening f))))

--- a/test/examples/dad/rendering/tags_test.clj
+++ b/test/examples/dad/rendering/tags_test.clj
@@ -13,3 +13,15 @@
     ; Sad paths
     (str "Command » foo echo « failed: java.io.IOException:"
          " Cannot run program \"foo\": error=2, No such file or directory")  "{% exec foo echo %}"))
+
+(deftest test-removeblanklines
+  (tags/register!)
+  (are [expected template] (= expected (sp/render template {}))
+    "Foo\nbar"
+    "{% removeblanklines %}Foo\n\nbar{% endremoveblanklines %}"
+    
+    "Foo\nbar\n"
+    "{% removeblanklines %}Foo\n\nbar\n\n\n\n{% endremoveblanklines %}"
+    
+    "\nFoo\nbar\n"
+    "{% removeblanklines %}\n\n\n\nFoo\n\n\n\nbar\n\n\n\n{% endremoveblanklines %}"))


### PR DESCRIPTION
I have templates in which I need to include some “custom” XHTML tags
that use namespaces, e.g. `<ac:structuredcontent>`

I have further need for those pages to be published to Confluence by
[md2c8e][1]. md2c8e converts all the Markdown documents to XHTML because
Confluence accepts content in that format. I ran into a problem wherein
the Markdown→HTML conversion process was escaping the tags.

For example, `<ac:parameter ac:name="">` in the Markdown document
(after rendering) would be turned into
`&lt;ac:parameter ac:name=&quot;&quot;&gt;`

I eventually stumbled across a strategy for preventing this:

* The [section on HTML Blocks][2] in the CommonMark spec says:

  > An HTML block is a group of lines that is treated as raw HTML (and
  > will not be escaped in HTML output).
* So I realized that if I wrap my namespaced XHTML tags in HTML
  `<section>` tags, they should be passed through unmolested. And
  indeed, they are.
* However, the “end condition” when creating a CommonMark HTML block
  this way is:

  > line is followed by a blank line

  Which meant that any blank lines within my `<section>` tag would
  “break” the block and thus my closing tags _would_ be escaped.
* Maybe someone else would have come up with a more elegant solution,
  but I was tired, so all I could think of was to just remove any blank
  lines inside the `<section>` tag.

So that’s what this does. And that’s why.

----

Resolves #9

----

If you’re super nerdy for this stuff, you could also check out
[the commonmark-java issue][3] I opened, entitled “How to pass through
custom tags?”.

[1]: https://github.com/FundingCircle/md2c8e/
[2]: https://spec.commonmark.org/0.29/#html-blocks
[3]: https://github.com/atlassian/commonmark-java/issues/172
