### PR TITLE
Custom tag exec should throw exceptions on error

### DIFF
--- a/test/examples/dad/rendering/tags_test.clj
+++ b/test/examples/dad/rendering/tags_test.clj
@@ -1,18 +1,25 @@
 (ns dad.rendering.tags-test
-  (:require [clojure.test :refer [are deftest]]
+  (:require [clojure.test :refer [are deftest is]]
             [dad.rendering.tags :as tags]
-            [selmer.parser :as sp]))
+            [selmer.parser :as sp])
+  (:import [clojure.lang ExceptionInfo]
+           [java.io IOException]))
 
 (deftest test-exec
   (tags/register!)
+
   (are [expected template] (= expected (sp/render template {}))
     ; Happy paths
     "foo bar"         "{% exec echo -n foo %} bar"
-    "LW4gZm9vCg==\n"  "{% exec /bin/sh -c \"echo -n foo | base64\" %}"
-    
-    ; Sad paths
-    (str "Command » foo echo « failed: java.io.IOException:"
-         " Cannot run program \"foo\": error=2, No such file or directory")  "{% exec foo echo %}"))
+    "LW4gZm9vCg==\n"  "{% exec /bin/sh -c \"echo -n foo | base64\" %}")
+
+  (is (thrown-with-msg? IOException
+                        #"^Cannot run program.+foo.+No such file"
+                        (sp/render "{% exec foo echo %}" {})))
+
+  (is (thrown-with-msg? ExceptionInfo
+                        #"^Command.+sh.+failed"
+                        (sp/render "{% exec /bin/sh -c 'exit 1' %}" {}))))
 
 (deftest test-removeblanklines
   (tags/register!)


### PR DESCRIPTION
In a downstream project I’ve been debugging a template that uses this
tag, and it’s failing, and I’ve realized that the current approach to
error handling — including the error output in the generated document
and continuing — is terrible. It’s basically failing silently.

So this changes the tag to fail fast on error by throwing Exceptions, which is similar to how Selmer’s built-in tags work.