### PR TITLE
Test on Java 8

### DIFF
--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, ubuntu-18.04]
-        java: [11, 13, 14]
+        java: [8, 11]
         suite: [examples] # We don’t have any other suites yet but we hope to, soon!
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I realized that:

* I’m planning to make native executables compiled via GraalVM’s
  native-image tool the recommended way to use DaD
* The script that builds those native executables and the GHA job that
  runs it currently use the Java 8 version of GraalVM, because I had
  some trouble with the Java 11 version, and as of now Java 8 is fine
  for this project.
* Until now the GHA job that runs the test suites has been testing on
  Java 11, 13, and 14.
* So we haven’t been testing on the most important Java version to test
  on!

So I added Java 8.

I also removed 13 and 14, because they’re irrelevant, and we don’t need
the noise in our GHA workflow runs. They’re irrelevant because they are
not LTS releases, and we certainly won’t ever be compiling our
executables with them.

I kept 11 because at some point soon-ish I plan to switching the
native executable compilation to 11. At that point we might drop 8. But
for now, I think it’s clear that we need it.